### PR TITLE
feat: exclude .next-bump from dist archives

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,5 +48,8 @@
     },
     "replace": {
         "oxid-esales/wave-theme": "1.6.2"
+    },
+    "archive": {
+        "exclude": [".next-bump"]
     }
 }


### PR DESCRIPTION
## Summary

Single-line addition to `composer.json`:

```json
"archive": {
    "exclude": [".next-bump"]
}
```

Belt-and-suspenders for the `bin/release` tag-cutting policy that lands in [o3-shop/shop-ce#121](https://github.com/o3-shop/shop-ce/pull/121) (issue [o3-shop/o3-shop#140](https://github.com/o3-shop/o3-shop/issues/140)). The CLI uses an optional `.next-bump` file at the repo root to let maintainers override the default patch bump per-release. This addition ensures that if a `.next-bump` file gets committed, it never ships in dist archives regardless of install path.

One-line, one-time addition. Inert until either a `.next-bump` file is committed AND a dist archive is built. Safe to merge on its own — no behavioural change today.

## Test plan

- [ ] `composer validate` passes (no schema regression)
- [ ] No expected change to existing build outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)