### PR TITLE
fix(#145): bump theme.php version to current tag (1.2.1)

### DIFF
--- a/theme.php
+++ b/theme.php
@@ -27,7 +27,7 @@ $aTheme = [
     'title'       => 'Wave',
     'description' => 'Wave is O3-Shops official responsive theme based on the CSS framework Bootstrap 4.',
     'thumbnail'   => 'theme.jpg',
-    'version'     => '1.1.0',
+    'version'     => '1.2.1',
     'author'      => '<a href="https://www.o3-shop.com" title="O3-Shop">O3-Shop</a>',
     'settings'    => [
         [


### PR DESCRIPTION
## Summary

Parallel fix for wave-theme: `theme.php`'s `'version'` line had been stuck at `1.1.0` across two subsequent releases (v1.2.0, v1.2.1). One-line bump to match the current tag. Sister fix to [o3-shop/o3-Theme#24](https://github.com/o3-shop/o3-Theme/pull/24).

## Follow-up

A separate change in `shop-ce` will wire `bin/release` to rewrite this line during the release-time commit so it stays in sync with the tag automatically — no maintainer edit per release, no drift. Tracked on shop-ce branch `145-bin-release-theme-version-bump`.

Refs: o3-shop/o3-shop#145

## Test plan

- [ ] Admin → Theme list shows version `1.2.1` for wave after pulling this branch