### PR TITLE
fix: contact map derives from shop address instead of placeholder

### DIFF
--- a/setup.sql
+++ b/setup.sql
@@ -26,7 +26,7 @@ INSERT INTO `oxconfig` (`OXID`, `OXSHOPID`, `OXMODULE`, `OXVARNAME`, `OXVARTYPE`
 (uuid(), 1, 'theme:wave', 'aNrofCatArticles', 'arr', 'a:4:{i:0;s:2:"10";i:1;s:2:"20";i:2;s:2:"50";i:3;s:3:"100";}', NOW()),
 (uuid(), 1, 'theme:wave', 'aNrofCatArticlesInGrid', 'arr', 'a:4:{i:0;s:2:"12";i:1;s:2:"16";i:2;s:2:"24";i:3;s:2:"32";}', NOW()),
 (uuid(), 1, 'theme:wave', 'bl_showManufacturerSlider', 'bool', '1', NOW()),
-(uuid(), 1, 'theme:wave', 'sGoogleMapsAddr', 'str', 'O3-Shop, Musterstr. 17, 12345 Musterstadt', NOW()),
+(uuid(), 1, 'theme:wave', 'sGoogleMapsAddr', 'str', '', NOW()),
 (uuid(), 1, 'theme:wave', 'blUseGAPageTracker', 'bool', '1', NOW()),
 (uuid(), 1, 'theme:wave', 'sGATrackingId', 'str', '', NOW()),
 (uuid(), 1, 'theme:wave', 'sFacebookUrl', 'str', 'https://www.facebook.com/', NOW()),

--- a/theme.php
+++ b/theme.php
@@ -371,7 +371,7 @@ $aTheme = [
             'group' => 'contact',
             'name'  => 'sGoogleMapsAddr',
             'type'  => 'str',
-            'value' => 'O3-Shop, Musterstraße 17, 12345 Musterstadt',
+            'value' => '',
         ],
         [
             'group' => 'footer',

--- a/tpl/page/info/contact.tpl
+++ b/tpl/page/info/contact.tpl
@@ -7,6 +7,10 @@
     <h1 class="page-header">[{oxmultilang ident="DD_CONTACT_PAGE_HEADING"}]</h1>
 
     [{assign var="sGoogleMapsAddr" value=$oViewConf->getViewThemeParam('sGoogleMapsAddr')}]
+    [{if !$sGoogleMapsAddr && $oxcmp_shop->oxshops__oxstreet->value}]
+        [{* No custom map address configured: derive it from the shop's contact address. *}]
+        [{assign var="sGoogleMapsAddr" value=$oxcmp_shop->oxshops__oxstreet->value|cat:", "|cat:$oxcmp_shop->oxshops__oxzip->value|cat:" "|cat:$oxcmp_shop->oxshops__oxcity->value|cat:", "|cat:$oxcmp_shop->oxshops__oxcountry->value}]
+    [{/if}]
     [{if $sGoogleMapsAddr}]
         [{*oxscript include="js/libs/pages/contact.min.js" priority=10*}]
 


### PR DESCRIPTION
## Summary

Fixes o3-shop/o3-shop#196 — the contact-page Google Map showed a fake "Musterstadt" placeholder location instead of the shop's address.

The map iframe read only the per-theme option `sGoogleMapsAddr`, whose factory default was a dummy address (`O3-Shop, Musterstr. 17, 12345 Musterstadt`). It was never linked to the shop's contact-address fields, so out of the box the map geocoded to an arbitrary location.

## Changes

- **`tpl/page/info/contact.tpl`** — when `sGoogleMapsAddr` is empty *and* the shop has a street, derive the map query from `oxstreet, oxzip oxcity, oxcountry`. Company name is deliberately excluded (a company name degrades geocoding).
- **`theme.php`** — install default for `sGoogleMapsAddr` changed to empty.
- **`setup.sql`** — DB seed for `sGoogleMapsAddr` changed to empty.

## Behaviour (verified live)

- Blank config → map derives the shop's contact address.
- Custom config → map uses the custom value (override preserved).
- Blank config + empty street → existing `[{if $sGoogleMapsAddr}]` guard hides the map (no broken geocode).

## Existing installs

The empty default only affects fresh installs. A shop that already stored the placeholder needs to clear it once via **Admin → Extensions → Themes → Wave → Settings → Contact → Google Maps Address**. No migration, by design.

## Companion PR

o3-Theme: https://github.com/o3-shop/o3-Theme/pull/32

Squash-merge candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)