### PR TITLE
feat(#213): render CAPTCHA widget into the 7 form blocks

### DIFF
--- a/tpl/form/contact.tpl
+++ b/tpl/form/contact.tpl
@@ -109,7 +109,7 @@
         </div>
     [{/block}]
 
-    [{block name="captcha_form"}][{/block}]
+    [{block name="captcha_form"}][{$oViewConf->getCaptchaWidget('contact')}][{/block}]
 
     [{block name="contact_form_buttons"}]
         <div class="form-group">

--- a/tpl/form/fieldset/user_billing.tpl
+++ b/tpl/form/fieldset/user_billing.tpl
@@ -217,8 +217,7 @@
     [{/if}]
 [{/block}]
 
-[{block name="captcha_form"}]
-[{/block}]
+[{block name="captcha_form"}][{$oViewConf->getCaptchaWidget('register')}][{/block}]
 
 <div class="form-group row">
     <div class="offset-lg-3 col-lg-9 col-12">

--- a/tpl/form/forgotpwd_email.tpl
+++ b/tpl/form/forgotpwd_email.tpl
@@ -24,7 +24,7 @@
                 <p class="help-block"></p>
             </div>
 
-            [{block name="captcha_form"}][{/block}]
+            [{block name="captcha_form"}][{$oViewConf->getCaptchaWidget('forgotpwd')}][{/block}]
 
             <div class="form-group">
                 <button class="btn btn-primary submitButton" type="submit">[{oxmultilang ident="REQUEST_PASSWORD"}]</button>

--- a/tpl/form/newsletter.tpl
+++ b/tpl/form/newsletter.tpl
@@ -51,7 +51,7 @@
         </div>
     [{/block}]
 
-    [{block name="captcha_form"}][{/block}]
+    [{block name="captcha_form"}][{$oViewConf->getCaptchaWidget('newsletter')}][{/block}]
 
     [{block name="newsletter_form_button"}]
         <div class="form-group">

--- a/tpl/form/pricealarm.tpl
+++ b/tpl/form/pricealarm.tpl
@@ -27,7 +27,7 @@
         </div>
     </div>
 
-    [{block name="captcha_form"}][{/block}]
+    [{block name="captcha_form"}][{$oViewConf->getCaptchaWidget('pricealarm')}][{/block}]
 
     <div class="form-group">
         <div class="col-lg-9 offset-lg-3">

--- a/tpl/form/privatesales/invite.tpl
+++ b/tpl/form/privatesales/invite.tpl
@@ -81,7 +81,7 @@
                 </p>
             </li>
 
-            [{block name="captcha_form"}][{/block}]
+            [{block name="captcha_form"}][{$oViewConf->getCaptchaWidget('invite')}][{/block}]
 
             <li class="formSubmit">
                 <button class="submitButton largeButton" type="submit">[{oxmultilang ident="SEND"}]</button>

--- a/tpl/form/suggest.tpl
+++ b/tpl/form/suggest.tpl
@@ -58,7 +58,7 @@
         </div>
     </div>
 
-    [{block name="captcha_form"}][{/block}]
+    [{block name="captcha_form"}][{$oViewConf->getCaptchaWidget('suggest')}][{/block}]
 
     <div class="form-group">
         <div class="col-lg-offset-2 col-lg-10">


### PR DESCRIPTION
## Summary

Fills the seven existing (empty) `captcha_form` template blocks so they render the active CAPTCHA provider's widget via `[{$oViewConf->getCaptchaWidget('<formId>')}]`.

This is the **wave** storefront half of the pluggable CAPTCHA feature. The widget markup + all provider logic live in **core** (o3-shop/shop-ce#180); this PR only wires the theme blocks to call the new `ViewConfig` method. When no CAPTCHA provider is active/configured, `getCaptchaWidget()` returns an empty string, so these blocks stay inert by default.

Forms wired: contact, newsletter, suggest, forgot-password, registration (`user_billing` fieldset → account page + checkout user step), price-alarm, invite.

Part of o3-shop/o3-shop#213. Companions: core PR o3-shop/shop-ce#180, provider module https://github.com/o3-shop/recaptcha-module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aRjjPnf9xxCc4xqRgsSvY
