### PR TITLE
[wave] Fix: register captcha blocks checkout for existing users (#217)

### DIFF
--- a/tpl/form/fieldset/user_billing.tpl
+++ b/tpl/form/fieldset/user_billing.tpl
@@ -217,7 +217,7 @@
     [{/if}]
 [{/block}]
 
-[{block name="captcha_form"}][{if method_exists($oViewConf, 'getCaptchaWidget')}][{$oViewConf->getCaptchaWidget('register')}][{/if}][{/block}]
+[{block name="captcha_form"}][{if !$oxcmp_user->oxuser__oxpassword->value && method_exists($oViewConf, 'getCaptchaWidget')}][{$oViewConf->getCaptchaWidget('register')}][{/if}][{/block}]
 
 <div class="form-group row">
     <div class="offset-lg-3 col-lg-9 col-12">


### PR DESCRIPTION
## Problem

Companion to o3-shop/o3-Theme#41, fixing o3-shop/o3-shop#217.

With the register CAPTCHA active, the register CAPTCHA widget was rendered for existing/logged-in customers during checkout even though no account is being created there. The widget injects a hidden **`required`** field inside the (hidden) billing form. In o3-theme this silently blocked checkout; wave avoids the hard block only because it has no `checkValidity()` script, but the stray hidden CAPTCHA is still wrong for existing users.

## Root cause

`user_billing.tpl` rendered `getCaptchaWidget('register')` unconditionally. For an existing user the checkout runs `changeUser()`, which never verifies the register CAPTCHA server-side (only `registerUser()` does).

## Fix

Render the register CAPTCHA only when an account is actually being created (no existing user password) — the same `createuser` vs `changeuser` predicate the surrounding templates already use:

```smarty
[{if !$oxcmp_user->oxuser__oxpassword->value && method_exists($oViewConf, 'getCaptchaWidget')}]
```

Keeps wave consistent with the o3-theme fix. New registrations (standalone register, checkout registration, guest) still show the CAPTCHA, always visible.